### PR TITLE
Fix node build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,9 @@ jobs:
       - image: cimg/node:15.10.0
     steps:
       - checkout
-      - node/install-packages:
-          pkg-manager: yarn
+      - run:
+          command: yarn install
+          name: Install
       - run:
           command: yarn build
           name: Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,9 @@
 version: 2.1
 
-orbs:
-  node: circleci/node@4.1.0
-
 jobs:
   build:
-    executor: node/default
+    docker:
+      - image: cimg/node:15.10.0
     steps:
       - checkout
       - node/install-packages:


### PR DESCRIPTION
Fix node build. Apparently, the `master` build failed because Gatsby needs a higher version of Node than 13.x.